### PR TITLE
Forced the calling convention to C when radiotap_iter.h is used in a …

### DIFF
--- a/radiotap_iter.h
+++ b/radiotap_iter.h
@@ -83,12 +83,18 @@ struct ieee80211_radiotap_iterator {
 	int _reset_on_ext;
 };
 
-extern int ieee80211_radiotap_iterator_init(
+#ifdef __cplusplus
+#define CALLING_CONVENTION "C"
+#else
+#define CALLING_CONVENTION
+#endif
+
+extern CALLING_CONVENTION int ieee80211_radiotap_iterator_init(
 	struct ieee80211_radiotap_iterator *iterator,
 	struct ieee80211_radiotap_header *radiotap_header,
 	int max_length, const struct ieee80211_radiotap_vendor_namespaces *vns);
 
-extern int ieee80211_radiotap_iterator_next(
+extern CALLING_CONVENTION int ieee80211_radiotap_iterator_next(
 	struct ieee80211_radiotap_iterator *iterator);
 
 #endif /* __RADIOTAP_ITER_H */


### PR DESCRIPTION
Added an extern modifier to ieee80211_radiotap_iterator_init and ieee80211_radiotap_iterator_next to specific the C calling convention if the library is used in a C++ project.