### PR TITLE
Changes to compile on OSX

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -4,9 +4,14 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <endian.h>
 #include <errno.h>
 #include <string.h>
+#if defined(__APPLE__)
+#include <machine/endian.h>
+#else
+#include <endian.h>
+#endif
+
 #include "radiotap_iter.h"
 
 static int fcshdr = 0;

--- a/platform.h
+++ b/platform.h
@@ -1,6 +1,10 @@
 #include <stddef.h>
 #include <errno.h>
+#if defined(__APPLE__)
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 
 #define le16_to_cpu		le16toh
 #define le32_to_cpu		le32toh

--- a/radiotap.h
+++ b/radiotap.h
@@ -16,6 +16,17 @@
 #ifndef __RADIOTAP_H
 #define __RADIOTAP_H
 
+#if defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#define bswap_16 OSSwapInt16
+#define bswap_32 OSSwapInt32
+#define bswap_64 OSSwapInt64
+#include <machine/endian.h>
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+#endif
+
 /**
  * struct ieee82011_radiotap_header - base radiotap header
  */


### PR DESCRIPTION
In OSX, 'endian.h' is now in 'machine/endian.h' and use 'libkern/OSByteOrder.h'.

Fix is similar to the issue n https://github.com/br101/horst/issues/3
