### PR TITLE
Replace '__packed' with '__attribute__'

### DIFF
--- a/radiotap.h
+++ b/radiotap.h
@@ -50,7 +50,7 @@ struct ieee80211_radiotap_header {
 	 * @it_present: (first) present word
 	 */
 	uint32_t it_present;
-} __packed;
+} __attribute__((__packed__));
 
 /* version is always 0 */
 #define PKTHDR_RADIOTAP_VERSION	0


### PR DESCRIPTION
Clang and GCC do not define `__packed`, which lead to compilation errors with current GCC 10 (see [here](https://github.com/seemoo-lab/owl/issues/32)) where the default `-fcommon` option changed to `-fno-common`.

Using `__attribute__((__packed__))` solves the problem.