### PR TITLE
Fix CMake and compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 project(radiotap)
 
 add_definitions("-D_BSD_SOURCE -DRADIOTAP_SUPPORT_OVERRIDES")

--- a/parse.c
+++ b/parse.c
@@ -39,7 +39,7 @@ static void print_radiotap_namespace(struct ieee80211_radiotap_iterator *iter)
 {
 	switch (iter->this_arg_index) {
 	case IEEE80211_RADIOTAP_TSFT:
-		printf("\tTSFT: %llu\n", le64toh(*(unsigned long long *)iter->this_arg));
+		printf("\tTSFT: %llu\n", (unsigned long long)le64toh(*(unsigned long long *)iter->this_arg));
 		break;
 	case IEEE80211_RADIOTAP_FLAGS:
 		printf("\tflags: %02x\n", *iter->this_arg);


### PR DESCRIPTION
Hi @jmberg, I am coming from the [aircrack-ng](https://github.com/aircrack-ng/aircrack-ng) project where this radiotap library is being utilized. Recently I started experimenting with the aircrack radiotap code which is a fork of your implementation. I noticed some warnings which I fixed and [submitted a PR](https://github.com/aircrack-ng/aircrack-ng/pull/2533) where it was suggested to me to submit these changes here also.

My changes:
- increased the minimum required CMake version to 2.8.12 which was [released in 2013](https://cmake.org/pipermail/cmake/2013-October/056020.html)
- added `-D_DEFAULT_SOURCE` according to [this manpage](https://man7.org/linux/man-pages/man7/feature_test_macros.7.html):
```
_BSD_SOURCE (deprecated since glibc 2.20)
...
              Since glibc 2.20, this macro is deprecated.  It now has
              the same effect as defining _DEFAULT_SOURCE, but generates
              a compile-time warning (unless _DEFAULT_SOURCE is also
              defined).  Use _DEFAULT_SOURCE instead.  To allow code
              that requires _BSD_SOURCE in glibc 2.19 and earlier and
              _DEFAULT_SOURCE in glibc 2.20 and later to compile without
              warnings, define both _BSD_SOURCE and _DEFAULT_SOURCE.
```
- added a missing `(unsigned long long)` cast to `parse.c`
- suppressed a `-Waddress-of-packed-member` in `radiotap.c`, this fix is part of the aircrack codebase since Jul 23, 2020 (https://github.com/aircrack-ng/aircrack-ng/commit/44f13dbc8eb9e0d811c68c0e6668cef76b268545, https://github.com/aircrack-ng/aircrack-ng/commit/998bc121b8b648a1cba964d5be1b058acef8d5b5)

Warnings before my fixes:
```
$ cmake .
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- The C compiler identification is GNU 12.2.1
-- The CXX compiler identification is GNU 12.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.6s)
-- Generating done (0.0s)
-- Build files have been written to: /home/gemesa/git-repos/radiotap-library

$ cmake --build .
[ 20%] Building C object CMakeFiles/radiotap.dir/radiotap.c.o
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdint.h:26,
                 from /usr/lib/gcc/x86_64-redhat-linux/12/include/stdint.h:9,
                 from /home/gemesa/git-repos/radiotap-library/radiotap_iter.h:4,
                 from /home/gemesa/git-repos/radiotap-library/radiotap.c:14:
/usr/include/features.h:194:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
  194 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
      |   ^~~~~~~
/home/gemesa/git-repos/radiotap-library/radiotap.c: In function ‘ieee80211_radiotap_iterator_init’:
/home/gemesa/git-repos/radiotap-library/radiotap.c:113:34: warning: taking address of packed member of ‘struct ieee80211_radiotap_header’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  113 |         iterator->_next_bitmap = &radiotap_header->it_present;
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 40%] Linking C shared library libradiotap.so
[ 40%] Built target radiotap
[ 60%] Building C object CMakeFiles/parse.dir/parse.c.o
In file included from /usr/include/sys/types.h:25,
                 from /home/gemesa/git-repos/radiotap-library/parse.c:1:
/usr/include/features.h:194:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
  194 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
      |   ^~~~~~~
/home/gemesa/git-repos/radiotap-library/parse.c: In function ‘print_radiotap_namespace’:
/home/gemesa/git-repos/radiotap-library/parse.c:42:36: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘__uint64_t’ {aka ‘long unsigned int’} [-Wformat=]
   42 |                 printf("\tTSFT: %llu\n", le64toh(*(unsigned long long *)iter->this_arg));
      |                                 ~~~^
      |                                    |
      |                                    long long unsigned int
      |                                 %lu
[ 80%] Linking C executable parse
[ 80%] Built target parse
[100%] Check examples
Checking 00.bin: OK
Checking 0.bin: OK
Checking 0fcs.bin: OK
Checking 0v0-2.bin: OK
Checking 0v0-3.bin: OK
Checking 0v0-4.bin: OK
Checking 0v0.bin: OK
Checking 1.bin: OK
Checking malformed-vendor.bin: OK
Checking unparsed-vendor.bin: OK
[100%] Built target radiotap_check
```

After my fixes:
```
$ cmake .
-- The C compiler identification is GNU 12.2.1
-- The CXX compiler identification is GNU 12.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.5s)
-- Generating done (0.0s)
-- Build files have been written to: /home/gemesa/git-repos/radiotap-library

$ cmake --build .
[ 20%] Building C object CMakeFiles/radiotap.dir/radiotap.c.o
[ 40%] Linking C shared library libradiotap.so
[ 40%] Built target radiotap
[ 60%] Building C object CMakeFiles/parse.dir/parse.c.o
[ 80%] Linking C executable parse
[ 80%] Built target parse
[100%] Check examples
Checking 00.bin: OK
Checking 0.bin: OK
Checking 0fcs.bin: OK
Checking 0v0-2.bin: OK
Checking 0v0-3.bin: OK
Checking 0v0-4.bin: OK
Checking 0v0.bin: OK
Checking 1.bin: OK
Checking malformed-vendor.bin: OK
Checking unparsed-vendor.bin: OK
[100%] Built target radiotap_check
```