### PR TITLE
Add Makefile generated by CMake to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 CMakeCache.txt
 CMakeFiles
 cmake_install.cmake
+Makefile


### PR DESCRIPTION
While working on #13 I noticed `Makefile` is not added to `.gitignore` but it should be because it is generated by CMake. So I added it.