### PR TITLE
build: set cmake_minimum_required to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(radiotap)
 
 add_definitions("-D_BSD_SOURCE -D_DEFAULT_SOURCE -DRADIOTAP_SUPPORT_OVERRIDES")


### PR DESCRIPTION
New cmake versions require at least 3.5 as 'cmake_minimum_required' in CMakeLists.txt. In future 3.10 will be required.