### PR TITLE
CMakeLists: fix compilation with Ninja build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,10 @@ set_target_properties(parse PROPERTIES
 target_link_libraries(parse radiotap)
 
 
+file(GLOB CHECK_FILES "${CMAKE_CURRENT_SOURCE_DIR}/check/*")
 add_custom_target(radiotap_check ALL
 		  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/check/check.sh ${CMAKE_CURRENT_BINARY_DIR}
-		  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/check/*
+		  DEPENDS ${CHECK_FILES}
 		  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/check/
 		  COMMENT "Check examples")
 add_dependencies(radiotap_check parse)


### PR DESCRIPTION
On using Ninja build system, the package currently don't configure correctly with the error:

ninja: error: 'check/*', needed by 'CMakeFiles/radiotap_check', missing and no known rule to make it

This is caused by the usage of

DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/check/*

that both CMake and Ninja doesn't expand to the list of all files in the check directory.

To better address this, use the CMake GLOB to first enumerate all the files in the check directory and then call DEPENDS on a variable containing the list of files.

This restore correct functionality and better adapt to CMake syntax.